### PR TITLE
 Allow looking up the course ID from the SKU, via a redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,33 @@ detail, here’s how:
    configuration).
 
 
+## I can’t use course IDs as SKUs. What do I do?
+
+Sometimes, configuring products with SKUs that match Open edX course
+IDs is not an option, or undesirable. For example, your Open edX
+platform may have several consecutive course runs that from a
+commercial perspective are all one and the same product. Or your
+selling platform might mandate a particular format for SKUs.
+
+In this case, you can use the [Django `redirects`
+app](https://docs.djangoproject.com/en/2.2/ref/contrib/redirects/) to
+help the webhook receiver find the correct course ID. For example, you
+might define https://my.lms.domain/sku/xyz123 to redirect to
+https://my.lms.domain/courses/course-v1:org+course+run/.
+
+What the webhook receiver will then do, if it detects a SKU that does
+not start with `course-v1:`, is send an HTTP `HEAD` request (with
+redirects enabled), to https://my.lms.domain/$prefix$sku (where
+`$prefix` is configurable, via `settings.WEBHOOK_RECEIVER_SKU_PREFIX`),
+and extract the course ID from the location it is being redirected to.
+
+The `redirects` app is enabled on a typical edX platform
+configuration, so it comes in handy for this purpose. However, in
+principle you do not _need_ to use it for looking up a course ID from
+a SKU. You could also write the redirect (or even a proxy rule) into
+your nginx configuration, or handle it at the load balancer level if
+your platform uses one.
+
 ## License
 
 This app is licensed under the Affero GPL; see [`LICENSE`](LICENSE) for

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,13 @@
 from __future__ import unicode_literals
 
+from django.conf import settings
 from django.test import TestCase
-from webhook_receiver.utils import hmac_is_valid
+
+from webhook_receiver.utils import hmac_is_valid, lookup_course_id
+from webhook_receiver.utils import SKULookupException
+
+import requests_mock
+from requests.exceptions import HTTPError
 
 
 class SignatureVerificationTest(TestCase):
@@ -36,3 +42,77 @@ class SignatureVerificationTest(TestCase):
 
         for triplet in incorrect_hmac:
             self.assertFalse(hmac_is_valid(*triplet))
+
+
+class SKULookupTest(TestCase):
+
+    def test_sku_roundtrip(self):
+        """When given a SKU that looks like a course ID, do we return it
+        unchanged?"""
+        sku = 'course-v1:org+course+run1'
+        course_id = sku
+        self.assertEqual(lookup_course_id(sku), course_id)
+
+    def test_successful_lookup(self):
+        """When given a SKU that resolves (via a redirect) to a course ID, do
+        we return that course ID correctly?"""
+        sku = 'course001'
+        course_id = 'course-v1:org+course+run1'
+        lookup_url = '%s/%s' % (settings.WEBHOOK_RECEIVER_EDX_OAUTH2_URL_ROOT,
+                                sku)
+        found_url = '%s/courses/%s/about' % (settings.WEBHOOK_RECEIVER_EDX_OAUTH2_URL_ROOT,  # noqa: E501
+                                             course_id)
+
+        with requests_mock.Mocker() as m:
+            m.register_uri('HEAD',
+                           lookup_url,
+                           status_code=301,
+                           headers={'Location': found_url})
+            m.register_uri('HEAD',
+                           found_url,
+                           status_code=200)
+            self.assertEqual(lookup_course_id(sku), course_id)
+
+    def test_broken_redirect(self):
+        """When given a SKU that resolves (via a redirect) to a non-existent
+        URL, do we throw an HTTPError?"""
+        sku = 'course001'
+        course_id = 'course-v1:org+course+run1'
+        lookup_url = '%s/%s' % (settings.WEBHOOK_RECEIVER_EDX_OAUTH2_URL_ROOT,
+                                sku)
+        found_url = '%s/courses/%s/about' % (settings.WEBHOOK_RECEIVER_EDX_OAUTH2_URL_ROOT,  # noqa: E501
+                                             course_id)
+
+        with requests_mock.Mocker() as m:
+            m.register_uri('HEAD',
+                           lookup_url,
+                           status_code=301,
+                           headers={'Location': found_url})
+            m.register_uri('HEAD',
+                           found_url,
+                           status_code=404)
+            with self.assertRaises(HTTPError):
+                lookup_course_id(sku)
+
+    def test_invalid_redirect(self):
+        """When given a SKU that resolves (via a redirect) to a URL that
+        exists but does not contain a course ID URL, do we throw a
+        SKULookupException?
+        """
+        sku = 'course001'
+        course_id = 'somebrokencourseid'
+        lookup_url = '%s/%s' % (settings.WEBHOOK_RECEIVER_EDX_OAUTH2_URL_ROOT,
+                                sku)
+        found_url = '%s/courses/%s/about' % (settings.WEBHOOK_RECEIVER_EDX_OAUTH2_URL_ROOT,  # noqa: E501
+                                             course_id)
+
+        with requests_mock.Mocker() as m:
+            m.register_uri('HEAD',
+                           lookup_url,
+                           status_code=301,
+                           headers={'Location': found_url})
+            m.register_uri('HEAD',
+                           found_url,
+                           status_code=200)
+            with self.assertRaises(SKULookupException):
+                lookup_course_id(sku)

--- a/webhook_receiver/settings/__init__.py
+++ b/webhook_receiver/settings/__init__.py
@@ -154,6 +154,10 @@ WEBHOOK_RECEIVER_EDX_OAUTH2_SECRET = env.str(
     'DJANGO_WEBHOOK_RECEIVER_EDX_OAUTH2_SECRET',
     default='')
 
+WEBHOOK_RECEIVER_SKU_PREFIX = env.str(
+    'DJANGO_WEBHOOK_RECEIVER_SKU_PREFIX',
+    default='')
+
 WEBHOOK_RECEIVER_SETTINGS = {
     'shopify': {
         'shop_domain': env.str(

--- a/webhook_receiver/settings/test.py
+++ b/webhook_receiver/settings/test.py
@@ -12,3 +12,24 @@ WEBHOOK_RECEIVER_SETTINGS = {
         'secret': 'secret',
     },
 }
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'standard': {
+            'format': '%(levelname)s '
+                      '[%(name)s] %(filename)s:%(lineno)d - %(message)s',
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'standard',
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'DEBUG',
+    },
+}

--- a/webhook_receiver_shopify/utils.py
+++ b/webhook_receiver_shopify/utils.py
@@ -4,7 +4,7 @@ import logging
 
 from django.db import transaction
 
-from webhook_receiver.utils import enroll_in_course
+from webhook_receiver.utils import enroll_in_course, lookup_course_id
 
 from .models import ShopifyOrder as Order
 from .models import ShopifyOrderItem as OrderItem
@@ -100,7 +100,8 @@ def process_line_item(order, item):
     # Create an enrollment for the line item. If the enrollment throws
     # an exception, we throw that exception up the stack so we can
     # attempt to retry order processing.
-    enroll_in_course(sku, email)
+    course_id = lookup_course_id(sku)
+    enroll_in_course(course_id, email)
 
     # Mark the item as processed
     order_item.finish_processing()

--- a/webhook_receiver_woocommerce/utils.py
+++ b/webhook_receiver_woocommerce/utils.py
@@ -4,7 +4,7 @@ import logging
 
 from django.db import transaction
 
-from webhook_receiver.utils import enroll_in_course
+from webhook_receiver.utils import enroll_in_course, lookup_course_id
 
 from .models import WooCommerceOrder as Order
 from .models import WooCommerceOrderItem as OrderItem
@@ -116,7 +116,8 @@ def process_line_item(order, item):
             order_item.save()
 
     # Create an enrollment for the line item
-    enroll_in_course(sku, email)
+    course_id = lookup_course_id(sku)
+    enroll_in_course(course_id, email)
 
     # Mark the item as processed
     order_item.finish_processing()


### PR DESCRIPTION
The general expectation is that the system invoking the webhook will have the product SKU configured to an Open edX course ID.

Sometimes, however, that is not an option, or at least is not desired. For example, an Open edX platform may have several
consecutive course runs that from a commercial perspective are all one and the same product. Thus, allow platform administrators to apply the following hack:

* Open edX exposes the Django `redirects` app, which allows platform administrators to define arbitrary HTTP redirects.

* An admin now has the option to define a redirect that allows a course lookup by SKU, and that redirects to a full course URL. For   example, they might use https://my.lms.domain/sku/xyz123 to redirect to https://my.lms.domain/courses/course-v1:org+course+run/.

* What the webhook receiver will now do, if it detects a SKU that does not start with `course-v1:`, is do an HTTP HEAD request (with redirects enabled), against https://my.lms.domain/$prefix$sku (where `$prefix` is configurable), and extract the course ID from the location it is being redirected to.