### PR TITLE
[SE-4288] Install service as a django app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,112 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
 .tox/
 .coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# Editors
+.vscode/
+.idea/
+
+# Misc
+.DS_Store
+TODO
+
 edx_webhooks.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ ENV/
 TODO
 
 edx_webhooks.sqlite3
+webhook_receiver.sqlite3

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,16 @@ setup(
         'django_fsm',
         'edx-rest-api-client>=1.9.2',
         'edx-auth-backends>=2.0.2',
+        'django-jsonfield-backport'
     ],
     setup_requires=[
         'setuptools-scm<6',
     ],
+    entry_points={
+        'lms.djangoapp': [
+            'webhook_receiver = webhook_receiver.apps:WebhookReceiverConfig',
+            'webhook_receiver_shopify = webhook_receiver_shopify.apps:WebhookReceiverShopifyConfig',
+            'webhook_receiver_woocommerce = webhook_receiver_woocommerce.apps:WebhookReceiverWoocommerceConfig',
+        ]
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Setup for the edX Webhooks app."""
+"""Setup for the webhook receiver app."""
 
 import os
 from setuptools import find_packages, setup
@@ -8,12 +8,12 @@ from setuptools import find_packages, setup
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
-    name='edx-webhooks',
+    name='webhook-receiver',
     use_scm_version=True,
     description='edX Webhooks: a webhook processor interfacing with Open edX',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
-    url='https://github.com/hastexo/edx-webhooks',
+    url='https://github.com/hastexo/webhook-receiver',
     author='hastexo',
     author_email='pypi@hastexo.com',
     license='AGPL-3.0',

--- a/webhook_receiver/apps.py
+++ b/webhook_receiver/apps.py
@@ -1,0 +1,34 @@
+"""
+edX receiver Django app configuration.
+"""
+
+from django.apps import AppConfig
+
+
+class WebhookReceiverConfig(AppConfig):
+    """
+    Configuration for the webhook receiver integration as an edX Django Plugin App.
+    Django Plugin App configuration to be able to use the module as a standalone edX Plugin App.
+    """
+
+    name = "edx_webhooks"
+    plugin_app = {
+        "url_config": {
+            "lms.djangoapp": {
+                "namespace": "webhook_receiver",
+            },
+        },
+        "settings_config": {
+            "lms.djangoapp": {
+                "common": {
+                    "relative_path": "plugin"
+                },
+                "devstack": {
+                    "relative_path": "plugin"
+                },
+                "production": {
+                    "relative_path": "plugin"
+                }
+            }
+        }
+    }

--- a/webhook_receiver/apps.py
+++ b/webhook_receiver/apps.py
@@ -11,7 +11,7 @@ class WebhookReceiverConfig(AppConfig):
     Django Plugin App configuration to be able to use the module as a standalone edX Plugin App.
     """
 
-    name = "edx_webhooks"
+    name = "webhook_receiver"
     plugin_app = {
         "url_config": {
             "lms.djangoapp": {

--- a/webhook_receiver/plugin.py
+++ b/webhook_receiver/plugin.py
@@ -43,20 +43,34 @@ def plugin_settings(settings):
         None
     """
 
-    settings.WEBHOOK_RECEIVER_LMS_BASE_URL = get_setting('LMS_BASE', default_val='http://localhost:18000')
+    settings.WEBHOOK_RECEIVER_LMS_BASE_URL = get_setting(
+        settings,
+        'LMS_BASE',
+        default_val='http://localhost:18000'
+    )
 
-    settings.WEBHOOK_RECEIVER_EDX_OAUTH2_KEY = get_setting('WEBHOOK_RECEIVER_EDX_OAUTH2_KEY')
-    settings.WEBHOOK_RECEIVER_EDX_OAUTH2_SECRET = get_setting('WEBHOOK_RECEIVER_EDX_OAUTH2_SECRET')
+    settings.WEBHOOK_RECEIVER_EDX_OAUTH2_KEY = get_setting(
+        settings,
+        'WEBHOOK_RECEIVER_EDX_OAUTH2_KEY'
+    )
 
-    settings.WEBHOOK_RECEIVER_SKU_PREFIX = get_setting('WEBHOOK_RECEIVER_SKU_PREFIX')
+    settings.WEBHOOK_RECEIVER_EDX_OAUTH2_SECRET = get_setting(
+        settings,
+        'WEBHOOK_RECEIVER_EDX_OAUTH2_SECRET'
+    )
+
+    settings.WEBHOOK_RECEIVER_SKU_PREFIX = get_setting(
+        settings,
+        'WEBHOOK_RECEIVER_SKU_PREFIX'
+    )
 
     settings.WEBHOOK_RECEIVER_SETTINGS = {
         'shopify': {
-            'shop_domain': get_setting('WEBHOOK_RECEIVER_SETTINGS_SHOPIFY_SHOP_DOMAIN'),
-            'api_key': get_setting('WEBHOOK_RECEIVER_SETTINGS_SHOPIFY_API_KEY'),
+            'shop_domain': get_setting(settings, 'WEBHOOK_RECEIVER_SETTINGS_SHOPIFY_SHOP_DOMAIN'),
+            'api_key': get_setting(settings, 'WEBHOOK_RECEIVER_SETTINGS_SHOPIFY_API_KEY'),
         },
         'woocommerce': {
             'source': get_setting(settings, "WEBHOOK_RECEIVER_WOOCOMMERCE_SOURCE"),
-            'secret': get_setting('WEBHOOK_RECEIVER_WOOCOMMERCE_SECRET'),
+            'secret': get_setting(settings, 'WEBHOOK_RECEIVER_WOOCOMMERCE_SECRET'),
         },
     }

--- a/webhook_receiver/plugin.py
+++ b/webhook_receiver/plugin.py
@@ -1,0 +1,62 @@
+"""
+edX webhooks Django Plugin App settings.
+"""
+
+import os
+
+
+def get_setting(settings, setting_key, default_val=None):
+    """
+    Retrieves the value of the requested setting
+
+    Gets the Value of an Environment variable either from
+    the OS Environment or from the settings ENV_TOKENS
+
+    Arguments:
+        - settings (dict): Django settings
+        - setting_key (str): String
+        - default_val (str): String
+
+    Returns:
+        - Value of the requested setting (String)
+    """
+
+    setting_val = os.environ.get(setting_key, default_val)
+
+    if hasattr(settings, "ENV_TOKENS"):
+        return settings.ENV_TOKENS.get(setting_key, setting_val)
+
+    return setting_val
+
+
+def plugin_settings(settings):
+    """
+    Specifies django environment settings
+
+    Extend django settings with the plugin defined ones to be able to configure
+    the plugin individually.
+
+    Arguments:
+        settings (dict): Django settings
+
+    Returns:
+        None
+    """
+
+    settings.WEBHOOK_RECEIVER_LMS_BASE_URL = get_setting('LMS_BASE', default_val='http://localhost:18000')
+
+    settings.WEBHOOK_RECEIVER_EDX_OAUTH2_KEY = get_setting('WEBHOOK_RECEIVER_EDX_OAUTH2_KEY')
+    settings.WEBHOOK_RECEIVER_EDX_OAUTH2_SECRET = get_setting('WEBHOOK_RECEIVER_EDX_OAUTH2_SECRET')
+
+    settings.WEBHOOK_RECEIVER_SKU_PREFIX = get_setting('WEBHOOK_RECEIVER_SKU_PREFIX')
+
+    settings.WEBHOOK_RECEIVER_SETTINGS = {
+        'shopify': {
+            'shop_domain': get_setting('WEBHOOK_RECEIVER_SETTINGS_SHOPIFY_SHOP_DOMAIN'),
+            'api_key': get_setting('WEBHOOK_RECEIVER_SETTINGS_SHOPIFY_API_KEY'),
+        },
+        'woocommerce': {
+            'source': get_setting(settings, "WEBHOOK_RECEIVER_WOOCOMMERCE_SOURCE"),
+            'secret': get_setting('WEBHOOK_RECEIVER_WOOCOMMERCE_SECRET'),
+        },
+    }

--- a/webhook_receiver_shopify/apps.py
+++ b/webhook_receiver_shopify/apps.py
@@ -1,0 +1,15 @@
+"""
+edX webhooks Django app configuration for Shopify integration.
+"""
+
+from django.apps import AppConfig
+
+
+class WebhookReceiverShopifyConfig(AppConfig):
+    """
+    Configuration for the Shopify integration as an edX Django Plugin App.
+    Django Plugin App configuration to be able to use the module as a standalone edX Plugin App.
+    """
+
+    name = "webhook_receiver_shopify"
+    plugin_app = {}

--- a/webhook_receiver_woocommerce/apps.py
+++ b/webhook_receiver_woocommerce/apps.py
@@ -1,0 +1,15 @@
+"""
+edX webhooks Django app configuration for Woocommerce integration.
+"""
+
+from django.apps import AppConfig
+
+
+class WebhookReceiverWoocommerceConfig(AppConfig):
+    """
+    Configuration for the Woocommerce integration as an edX Django Plugin App.
+    Django Plugin App configuration to be able to use the module as a standalone edX Plugin App.
+    """
+
+    name = "webhook_receiver_woocommerce"
+    plugin_app = {}


### PR DESCRIPTION
Since the application could be installed as a plugin rather than a standalone service, this PR refactors the code to be able to install the install the app as an edX Django Plugin App.

The plugin configuration is intentionally not placed inside the settings module to avoid confusion and install of unrelated requirements like environ or dotent dependencies.

Dependencies: None

Screenshots:

<img width="678" alt="Screenshot 2021-04-14 at 9 12 17" src="https://user-images.githubusercontent.com/19173947/114669502-40f18e80-9d02-11eb-8047-89d43ddbb0ba.png">

Sandbox URL: TBD - sandbox is being provisioned.

Testing instructions:

1. Start edX lms service
2. pip install the app by executing `sudo -E -u edxapp env "PATH=$PATH" /edx/app/edxapp/venvs/edxapp/bin/python -m pip install -e git+https://github.com/open-craft/webhook-receiver.git@gabor/run-as-plugin-app#egg=webhook-receiver`
3. restart LMS
4. check the admin of LMS to find the 4 registered tables. 2 for woocommerce and 2 for shopify

Author notes and concerns:

* I did extend `.gitignore` and removed the unnecessary `.gitsubmodules`.