### PR TITLE
Make testing in GitHub Actions workflow more reliable, and simplify local testing

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec tox -e flake8

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec tox -r

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,6 +21,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install tox tox-gh-actions 'setuptools_scm<6'
+        pip install tox tox-gh-actions tox-pip-version 'setuptools_scm<6'
     - name: Test with tox
+      env:
+        TOX_PIP_VERSION: '20.2.4'
       run: tox

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.8]
+        python-version:
+          - 3.5
+          - 3.8
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,6 +21,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install tox tox-gh-actions
+        pip install tox tox-gh-actions 'setuptools_scm<6'
     - name: Test with tox
       run: tox

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,35 @@
+Developer notes
+===============
+
+This document is for people who maintain and contribute to this
+repository.
+
+
+How to run tests
+----------------
+
+This repo uses [tox](https://tox.readthedocs.io/) for unit and
+integration tests. It does not install `tox` for you, you should
+follow [the installation
+instructions](https://tox.readthedocs.io/en/latest/install.html) if
+your local setup does not yet include `tox`.
+
+You are encouraged to set up your checkout such
+that the tests run on every commit, and on every push. To do so, run
+the following command after checking out this repository:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Once your checkout is configured in this manner, every commit will run
+a code style check (with [Flake8](https://flake8.pycqa.org/)), and
+every push to a remote topic branch will result in a full `tox` run.
+
+In addition, we use [GitHub
+Actions](https://docs.github.com/en/actions) to run the same checks
+on every push to GitHub.
+
+*If you absolutely must,* you can use the `--no-verify` flag to `git
+commit` and `git push` to bypass local checks, and rely on GitHub
+Actions alone. But doing so is strongly discouraged.

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,5 +3,3 @@ coverage
 django-webtest
 requests-mock
 tox
-amqp
-mysqlclient

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         'django-celery>=3.2.1',
         'django_fsm',
         'edx-rest-api-client>=1.9.2',
-        'edx-auth-backends>=2.0.2',
     ],
     setup_requires=[
         'setuptools-scm<6',

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,12 @@ from setuptools import find_packages, setup
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
-    name='edx-webhooks',
+    name='webhook-receiver',
     use_scm_version=True,
     description='edX Webhooks: a webhook processor interfacing with Open edX',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
-    url='https://github.com/hastexo/edx-webhooks',
+    url='https://github.com/hastexo/webhook-receiver',
     author='hastexo',
     author_email='pypi@hastexo.com',
     license='AGPL-3.0',

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
         'edx-rest-api-client>=1.9.2',
     ],
     setup_requires=[
-        'setuptools-scm<6',
+        'setuptools_scm<6',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -30,8 +30,9 @@ deps =
      koa: -rrequirements/koa.txt
 
 [testenv:flake8]
+skip_install = True
 deps = -rrequirements/flake8.txt
-commands = flake8
+commands = flake8 []
 
 [testenv:reno]
 commands = reno []


### PR DESCRIPTION
This includes several changes to un-break GitHub Actions workflows:

- Use `pip`<20.3 in `tox` runs, to work around ongoing issues with pip's "new" dependency resolver.
- Install `setuptools_scm<6` directly from within the workflow.
- Speed up `flake8` testing (and resolve some more dependency installation issues)

In addition, this simplifies testing in a local checkout:

- Facilitate local testing by shipping pre-commit and pre-push hooks in `.githooks`.
- Add instructions in `HACKING.md` for setting up one's local checkout to enable these hooks.