### PR TITLE
Add toggles for automatic enrollment, and for enrollment email

### DIFF
--- a/webhook_receiver/settings/__init__.py
+++ b/webhook_receiver/settings/__init__.py
@@ -158,6 +158,11 @@ WEBHOOK_RECEIVER_SKU_PREFIX = env.str(
     'DJANGO_WEBHOOK_RECEIVER_SKU_PREFIX',
     default='')
 
+WEBHOOK_RECEIVER_AUTO_ENROLL = env.bool(
+    'DJANGO_WEBHOOK_RECEIVER_AUTO_ENROLL',
+    default=True
+)
+
 WEBHOOK_RECEIVER_SETTINGS = {
     'shopify': {
         'shop_domain': env.str(

--- a/webhook_receiver/settings/__init__.py
+++ b/webhook_receiver/settings/__init__.py
@@ -163,6 +163,11 @@ WEBHOOK_RECEIVER_AUTO_ENROLL = env.bool(
     default=True
 )
 
+WEBHOOK_RECEIVER_SEND_ENROLLMENT_EMAIL = env.bool(
+    'DJANGO_WEBHOOK_RECEIVER_SEND_ENROLLMENT_EMAIL',
+    default=True
+)
+
 WEBHOOK_RECEIVER_SETTINGS = {
     'shopify': {
         'shop_domain': env.str(

--- a/webhook_receiver/utils.py
+++ b/webhook_receiver/utils.py
@@ -132,7 +132,8 @@ def lookup_course_id(sku):
 
 def enroll_in_course(course_id,
                      email,
-                     send_email=True):
+                     send_email=True,
+                     auto_enroll=settings.WEBHOOK_RECEIVER_AUTO_ENROLL):
     """
     Auto-enroll email in course.
 
@@ -156,7 +157,7 @@ def enroll_in_course(course_id,
     # enrollments one by one, so we use a single request for each
     # course/identifier combination.
     request_params = {
-        "auto_enroll": True,
+        "auto_enroll": auto_enroll,
         "email_students": send_email,
         "action": "enroll",
         "courses": course_id,

--- a/webhook_receiver/utils.py
+++ b/webhook_receiver/utils.py
@@ -130,10 +130,12 @@ def lookup_course_id(sku):
                              'matching SKU %s' % sku)
 
 
-def enroll_in_course(course_id,
-                     email,
-                     send_email=True,
-                     auto_enroll=settings.WEBHOOK_RECEIVER_AUTO_ENROLL):
+def enroll_in_course(
+        course_id,
+        email,
+        send_email=settings.WEBHOOK_RECEIVER_SEND_ENROLLMENT_EMAIL,
+        auto_enroll=settings.WEBHOOK_RECEIVER_AUTO_ENROLL
+):
     """
     Auto-enroll email in course.
 


### PR DESCRIPTION
We previously defaulted to always auto-enroll learners, and to always send them enrollment email. Make that behavior configurable.