### PR TITLE
Support the WooCommerce dummy webhook invocation

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -191,6 +191,22 @@ class WooCommerceTestOrderCreation(WooCommerceTestCase):
         response = self.client.get('/webhooks/woocommerce/order/create')
         self.assertEqual(response.status_code, 405)
 
+    def test_invalid_content_type(self):
+        response = self.client.post('/webhooks/woocommerce/order/create',
+                                    content_type='multipart/form-data')
+        self.assertEqual(response.status_code, 400)
+
+    def test_invalid_x_www_form_urlencoded(self):
+        response = self.client.post('/webhooks/woocommerce/order/create',
+                                    content_type='application/x-www-form-urlencoded')  # noqa: E501
+        self.assertEqual(response.status_code, 400)
+
+    def test_valid_x_www_form_urlencoded(self):
+        response = self.client.post('/webhooks/woocommerce/order/create',
+                                    'webhook_id=1',
+                                    content_type='application/x-www-form-urlencoded')  # noqa: E501
+        self.assertEqual(response.status_code, 200)
+
     def test_missing_hmac_header(self):
         response = self.client.post('/webhooks/woocommerce/order/create',
                                     self.raw_payload,


### PR DESCRIPTION
When WooCommerce web hooks are first created or enabled, WooCommerce sends a POST request whose content type is not `application/json`, but instead `application/x-www-form-urlencoded` with a single form value: `webhook_id=<num>`

This request does not contain a signature nor a valid source header, so there is little we can do to verify that the webhook is properly signed. But WooCommerce will show an error if the test POST to the webhook returns anything but HTTP 200.

So, simply check for the content type and the presence of the webhook_id form value, and return HTTP 200 to keep the WooCommerce admin happy. If we receive something that is `application/x-www-form-urlencoded` but does not contain `webhook_id`, log a warning message instead.