### PR TITLE
Add the "mail_admins" logging handler to the production settings

### DIFF
--- a/webhook_receiver/settings/__init__.py
+++ b/webhook_receiver/settings/__init__.py
@@ -91,15 +91,20 @@ LOGGING = {
             'formatter': 'syslog_format',
             'facility': SysLogHandler.LOG_LOCAL0,
         },
+        'mail_admins': {
+            'level': 'ERROR',
+            'filters': ['require_debug_false'],
+            'class': 'django.utils.log.AdminEmailHandler'
+        },
     },
     'loggers': {
         'django': {
-            'handlers': ['console', 'local'],
+            'handlers': ['console', 'local', 'mail_admins'],
             'propagate': False,
             'level': 'INFO'
         },
         'requests': {
-            'handlers': ['console', 'local'],
+            'handlers': ['console', 'local', 'mail_admins'],
             'propagate': True,
             'level': 'WARNING'
         },
@@ -109,7 +114,7 @@ LOGGING = {
             'level': 'WARNING'
         },
         'django.request': {
-            'handlers': ['console', 'local'],
+            'handlers': ['console', 'local', 'mail_admins'],
             'propagate': True,
             'level': 'WARNING'
         },


### PR DESCRIPTION
Since receiving webhooks is potentially a business-critical process, we want to give administrators the ability to set the `ADMINS` and `DEFAULT_FROM_EMAIL` options and receive email messages any time we run into an `ERROR` condition.

To that end, define a `mail_admins` handler and add it to the `django` and `django.requests` loggers. Also add it to the `requests` logger, to catch errors in interactions with the LMS REST API.

This handler does nothing if

* we're in `DEBUG` mode,
* `ADMINS` is unset or empty.