### PR TITLE
Define require_debug_false filter in default logging configuration

### DIFF
--- a/webhook_receiver/settings/__init__.py
+++ b/webhook_receiver/settings/__init__.py
@@ -77,6 +77,11 @@ LOGGING = {
         },
         'syslog_format': {'format': syslog_format},
     },
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse',
+        },
+    },
     'handlers': {
         'console': {
             'level': 'INFO',


### PR DESCRIPTION
The changed logging configuration in 01e5457e1c96d36e56da6b2946768576028ab506 omitted defining the `require_debug_false` filter, which would break logging unless the configuration overrode `LOGGING`.

Define the filter so it can be correctly referenced.