### PR TITLE
Fix client IP lookup in WooCommerce dummy webhook

### DIFF
--- a/webhook_receiver_woocommerce/views.py
+++ b/webhook_receiver_woocommerce/views.py
@@ -9,6 +9,8 @@ from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
+from ipware import get_client_ip
+
 from webhook_receiver.utils import receive_json_webhook, hmac_is_valid
 from webhook_receiver.utils import fail_and_save, finish_and_save
 from .utils import record_order
@@ -33,7 +35,7 @@ def order_create_or_update(request):
     # send a Bad Request response.
     content_type = request.content_type
     if content_type != 'application/json':
-        remote_host = request.get_host()
+        remote_host, is_routable = get_client_ip(request)
         user_agent = request.headers.get('user-agent')
         if content_type == 'application/x-www-form-urlencoded':
             try:


### PR DESCRIPTION
The client IP lookup used for logging the incoming WooCommerce webhook activation POST request, introduced in 8e6b554df8e5dee3dbf4bea10e6c83ea82d50f30, looked up the server host instead.

Use `ipware`'s `get_client_ip()` method instead, like we already do elsewhere.