### PR TITLE
Fix GitLab CI pipeline, remove setuptools_scm restriction from GitHub Actions workflow definition

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install tox tox-gh-actions tox-pip-version 'setuptools_scm<6'
+        pip install tox tox-gh-actions tox-pip-version
     - name: Test with tox
       env:
         TOX_PIP_VERSION: '20.2.4'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,8 +5,11 @@ stages:
 py38:
   image: python:3.8
   stage: build
+  variables:
+    TOX_PIP_VERSION: '20.2.4'
+  before_script:
+    - pip install tox tox-pip-version
   script:
-    - pip install tox
     - tox -e py38-lilac,py38-maple,flake8
   artifacts:
     paths:


### PR DESCRIPTION
* Unbreak the GitLab CI pipeline by working around a dependency resolver loop in pip
* Remove an unnecessary version constraint for `setuptools_scm` from the GitHub Actions workflow definition