### PR TITLE
Update lilac branch

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install tox tox-gh-actions tox-pip-version 'setuptools_scm<6'
+        pip install tox tox-gh-actions tox-pip-version
     - name: Test with tox
       env:
         TOX_PIP_VERSION: '20.2.4'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,23 +2,15 @@ stages:
   - build
   - report
 
-py35:
-  image: python:3.5
-  stage: build
-  script:
-    - pip install tox
-    - tox -e py35-juniper,py35-latest,flake8
-  artifacts:
-    paths:
-      - .coverage*
-    expire_in: 5 minutes
-
 py38:
   image: python:3.8
   stage: build
+  variables:
+    TOX_PIP_VERSION: '20.2.4'
+  before_script:
+    - pip install tox tox-pip-version
   script:
-    - pip install tox
-    - tox -e py38-juniper,py38-latest,flake8
+    - tox -e py38-lilac,flake8
   artifacts:
     paths:
       - .coverage*

--- a/requirements/koa.txt
+++ b/requirements/koa.txt
@@ -1,6 +1,0 @@
--r base.txt
-celery<4.5
-django<2.3
-edx-rest-api-client<5.3
-pyyaml<5.4
-django-jsonfield-backport

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = py38-{koa,lilac},flake8,report
+envlist = py38-lilac,flake8,report
 
 [gh-actions]
 python =
-    3.8: py38-koa,py38-lilac,flake8
+    3.8: py38-lilac,flake8
 
 [flake8]
 ignore = E124
@@ -25,7 +25,6 @@ commands = coverage run manage.py test --settings webhook_receiver.settings.test
 passenv = DJANGO_*
 deps =
      -rrequirements/test.txt
-     koa: -rrequirements/koa.txt
      lilac: -rrequirements/lilac.txt
 
 [testenv:flake8]


### PR DESCRIPTION
Cherry-pick a few recent fixes from #13 over into the `lilac` branch:

1. Drop Koa support
2. Fix GitLab CI pipeline
3. Remove `setuptools_scm` version restriction

3 is a clean cherry-pick. 1 and 2 exclude the Open edX references we have in `main` (and `maple`).