### PR TITLE
Add a test harness for settings

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,54 @@
+from importlib import reload
+from django.test import SimpleTestCase
+
+from webhook_receiver import settings as default_settings
+from webhook_receiver.settings import production as production_settings
+
+
+class DefaultSettingsTest(SimpleTestCase):
+    """Tests for default settings (webhook_receiver.settings)
+
+    This class inherits from SimpleTestCase, rather than TestCase: the
+    latter mangles the database settings for testing purposes. We
+    don't want that here, since one of the things we're testing is
+    precisely those database settings.
+    """
+
+    def setUp(self):
+        # Make sure we reload the module at the start of the test run
+        self.settings = reload(default_settings)
+
+    def test_default_db_settings(self):
+        default_db = self.settings.DATABASES['default']
+        self.assertEqual(default_db['HOST'], '')
+        self.assertEqual(default_db['PORT'], '')
+        self.assertEqual(
+            default_db['ENGINE'],
+            'django.db.backends.sqlite3'
+        )
+        self.assertEqual(default_db['NAME'], ':memory:')
+        self.assertEqual(default_db['USER'], '')
+        self.assertEqual(default_db['PASSWORD'], '')
+        self.assertEqual(default_db['OPTIONS'], {})
+
+
+class ProductionSettingsTest(DefaultSettingsTest):
+    """Tests for production settings (webhook_receiver.settings.production)
+
+    This class runs all tests for default settings, albeit with the
+    production configuration. Any test methods that should behave
+    differently from the default settings should be overriden here."""
+
+    def setUp(self):
+        # Make sure we reload the module at the start of the test run
+        self.settings = reload(production_settings)
+
+    def test_db_overrides(self):
+        # Absent any environment variables, DB_OVERRIDES should not
+        # change the default database settings
+        default_db = self.settings.DATABASES['default']
+        db_overrides = self.settings.DB_OVERRIDES
+        for key in ['NAME', 'HOST', 'PORT', 'ENGINE', 'USER',
+                    'PASSWORD', 'OPTIONS']:
+            if db_overrides[key]:
+                self.assertEqual(default_db[key], db_overrides[key])

--- a/webhook_receiver/settings/__init__.py
+++ b/webhook_receiver/settings/__init__.py
@@ -149,7 +149,6 @@ default_db = env.db(
     'DJANGO_DATABASE_URL',
     default='sqlite:///:memory:'
 )
-
 if not default_db:
     # env.db() returns an empty dictionary if DJANGO_DATABASE_URL is
     # set to an empty string. This will break when we want to override
@@ -158,7 +157,10 @@ if not default_db:
         'DJANGO_DATABASE_URL was set to an empty string. Provide a '
         'valid URL or unset DJANGO_DATABASE_URL to use the default.'
     )
-
+# If the database URL sets options via "?key=value" parameters, we
+# want to use them.  But if it doesn't, we still want to set OPTIONS
+# to an empty dictionary, which django-environ doesn't do by default.
+default_db.setdefault('OPTIONS', {})
 DATABASES = {
     'default': default_db,
 }

--- a/webhook_receiver/settings/production.py
+++ b/webhook_receiver/settings/production.py
@@ -35,7 +35,6 @@ DB_OVERRIDES = dict(
     HOST=env.str('DB_MIGRATION_HOST', default=None),  # noqa: F405
     PORT=env.str('DB_MIGRATION_PORT', default=None),  # noqa: F405
     OPTIONS=env.json('DB_MIGRATION_OPTIONS', default=None),  # noqa: F405
-
 )
 for override, value in DB_OVERRIDES.items():
     if value:

--- a/webhook_receiver/settings/production.py
+++ b/webhook_receiver/settings/production.py
@@ -28,23 +28,18 @@ if CONFIG_FILE:
 # The "make migrate" ("manage.py migrate") functionality needs to
 # honour the DB_MIGRATION_ environment variables.
 DB_OVERRIDES = dict(
-    PASSWORD=env.str('DB_MIGRATION_PASS',  # noqa: F405
-                     default=DATABASES['default']['PASSWORD']),  # noqa: F405
-    ENGINE=env.str('DB_MIGRATION_ENGINE',  # noqa: F405
-                   default=DATABASES['default']['ENGINE']),  # noqa: F405
-    USER=env.str('DB_MIGRATION_USER',  # noqa: F405
-                 default=DATABASES['default']['USER']),  # noqa: F405
-    NAME=env.str('DB_MIGRATION_NAME',  # noqa: F405
-                 default=DATABASES['default']['NAME']),  # noqa: F405
-    HOST=env.str('DB_MIGRATION_HOST',  # noqa: F405
-                 default=DATABASES['default']['HOST']),  # noqa: F405
-    PORT=env.str('DB_MIGRATION_PORT',  # noqa: F405
-                 default=DATABASES['default']['PORT']),  # noqa: F405
-    OPTIONS=env.json('DB_MIGRATION_OPTIONS',  # noqa: F405
-                     default=DATABASES['default']['OPTIONS']),  # noqa: F405
+    PASSWORD=env.str('DB_MIGRATION_PASS', default=None),  # noqa: F405
+    ENGINE=env.str('DB_MIGRATION_ENGINE', default=None),  # noqa: F405
+    USER=env.str('DB_MIGRATION_USER', default=None),  # noqa: F405
+    NAME=env.str('DB_MIGRATION_NAME', default=None),  # noqa: F405
+    HOST=env.str('DB_MIGRATION_HOST', default=None),  # noqa: F405
+    PORT=env.str('DB_MIGRATION_PORT', default=None),  # noqa: F405
+    OPTIONS=env.json('DB_MIGRATION_OPTIONS', default=None),  # noqa: F405
+
 )
 for override, value in DB_OVERRIDES.items():
-    DATABASES['default'][override] = value  # noqa: F405
+    if value:
+        DATABASES['default'][override] = value  # noqa: F405
 
 # The one thing we don't allow to be set in production, neither from
 # the environment nor from a config file, is DEBUG == True.


### PR DESCRIPTION
Add a test module for settings, so we can make sure that our settings are what we expect them to be:

* `DefaultSettingsTest` is meant for testing the default settings, i.e. what we define in `webhook_receiver.settings.__init__.py`.

* `ProductionSettingsTest` is meant for testing what's in `webhook_receiver.settings.production.py`. It inherits from DefaultSettingsTests so it runs the same tests, just with the production settings. Wherever the configuration settings differ, we can add method overrides (or additional tests).