### PR TITLE
Remove mock from test requirements

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,3 @@
-mock
 coverage
 django-webtest
 requests-mock


### PR DESCRIPTION
We've never supported any Python version that didn't include `unittest.mock`, so there's no reason to include the `mock` package in `requirements/test.txt`. Remove it.