### PR TITLE
Bump production requirements to Maple

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,4 +1,4 @@
--r lilac.txt
+-r maple.txt
 gunicorn
 gevent
 python-memcached


### PR DESCRIPTION
In 28ec328d2f2b23640886fd56c62b2b8203abbf0c, we neglected to update the `requirements/production.txt` file so that it inherits from `maple.txt`, not `lilac.txt`.