### PR TITLE
Expose the require_payment setting for WooCommerce via env

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install tox tox-gh-actions tox-pip-version
+        pip install 'tox<4' tox-gh-actions tox-pip-version
     - name: Test with tox
       env:
         TOX_PIP_VERSION: '20.2.4'

--- a/webhook_receiver/settings/__init__.py
+++ b/webhook_receiver/settings/__init__.py
@@ -215,5 +215,8 @@ WEBHOOK_RECEIVER_SETTINGS = {
         'secret': env.str(
             'DJANGO_WEBHOOK_RECEIVER_SETTINGS_WOOCOMMERCE_SECRET',
             default=''),
+        'require_payment': env.bool(
+            'DJANGO_WEBHOOK_RECEIVER_SETTINGS_WOOCOMMERCE_REQUIRE_PAYMENT',
+            default=False),
     },
 }


### PR DESCRIPTION
Without this change, we have no way to set the `require_payment` configuration option for the WooCommerce webhook receiver via an environment variable.

Expose it via `env.bool()`.
