### PR TITLE
Support Nutmeg–Quince, make line item processing for WooCommerce more robust

### DIFF
--- a/requirements/nutmeg.txt
+++ b/requirements/nutmeg.txt
@@ -1,0 +1,5 @@
+-r base.txt
+celery~=5.2.6
+django~=3.2.16
+edx-rest-api-client~=5.5.0
+pyyaml~=6.0

--- a/requirements/olive.txt
+++ b/requirements/olive.txt
@@ -1,0 +1,5 @@
+-r base.txt
+celery~=5.2.7
+django~=3.2.16
+edx-rest-api-client~=5.5.0
+pyyaml~=6.0

--- a/requirements/palm.txt
+++ b/requirements/palm.txt
@@ -1,0 +1,5 @@
+-r base.txt
+celery~=5.2.7
+django~=3.2.20
+edx-rest-api-client~=5.5.0
+pyyaml~=6.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,4 +1,4 @@
--r maple.txt
+-r quince.txt
 gunicorn
 gevent
 python-memcached

--- a/requirements/quince.txt
+++ b/requirements/quince.txt
@@ -1,0 +1,5 @@
+-r base.txt
+celery~=5.3.4
+django~=4.2.10
+edx-rest-api-client~=5.6.1
+pyyaml~=6.0.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = py38-{lilac,maple},flake8,report
+envlist = py38-{lilac,maple,nutmeg,olive,palm,quince},flake8,report
 
 [gh-actions]
 python =
-    3.8: py38-lilac,py38-maple,flake8
+    3.8: py38-lilac,py38-maple,py38-nutmeg,py38-olive,py38-palm,py38-quince,flake8
 
 [flake8]
 ignore = E124
@@ -27,6 +27,10 @@ deps =
      -rrequirements/test.txt
      lilac: -rrequirements/lilac.txt
      maple: -rrequirements/maple.txt
+     nutmeg: -rrequirements/nutmeg.txt
+     olive: -rrequirements/olive.txt
+     palm: -rrequirements/palm.txt
+     quince: -rrequirements/quince.txt
 
 [testenv:flake8]
 skip_install = True

--- a/webhook_receiver/settings/test.py
+++ b/webhook_receiver/settings/test.py
@@ -2,6 +2,8 @@ from . import *  # noqa: F401, F403
 
 SECRET_KEY = 'not-so-secret pass phrase used for testing'
 
+ALLOWED_HOSTS = ['127.0.0.1', '::1']
+
 WEBHOOK_RECEIVER_SETTINGS = {
     'shopify': {
         'shop_domain': 'example.com',


### PR DESCRIPTION
* Update the requirements list (and the test matrix) so we cover the Open edX Nutmeg, Olive, Palm, and Quince releases.
* Add `ALLOWED_HOSTS` to the test settings (required in Django 4+).
* Fix line item processing in WooCommerce to make it more robust. Add a test case.