### PR TITLE
feat: Support environment variable to set ALLOWED_HOSTS

### DIFF
--- a/releasenotes/notes/allowed-hosts-61b819dff9a67e61.yaml
+++ b/releasenotes/notes/allowed-hosts-61b819dff9a67e61.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Support the DJANGO_ALLOWED_HOSTS environment variable.
+    Set this to a comma-separated list of allowed host names.
+    Setting this is required from Django 4 forward.

--- a/webhook_receiver/settings/__init__.py
+++ b/webhook_receiver/settings/__init__.py
@@ -61,6 +61,8 @@ SECRET_KEY = env.str('DJANGO_SECRET_KEY', default=None)
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool('DJANGO_DEBUG', default=False)
 
+ALLOWED_HOSTS = env.list('DJANGO_ALLOWED_HOSTS', default=[])
+
 hostname = platform.node().split(".")[0]
 syslog_address = '/var/run/syslog' if platform.system().lower() == 'darwin' else '/dev/log'  # noqa: E501
 syslog_format = '[service_variant=webhook_receiver]' \


### PR DESCRIPTION
In Django 4+ (as used from Open edX Quince forward), an application will refuse to start if `ALLOWED_HOSTS` is an empty list.

Thus, we need a means to set `ALLOWED_HOSTS` from an environment variable, like we do with other Django settings. To that end, introduce `DJANGO_ALLOWED_HOSTS`.